### PR TITLE
Suggestions to Docker setup

### DIFF
--- a/docker/buoy/Dockerfile
+++ b/docker/buoy/Dockerfile
@@ -1,65 +1,31 @@
 FROM ros:galactic-ros-base
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Useful tools
+# Necessary tools
 RUN apt update \
  && apt install -y \
-        apt-utils \
-        build-essential \
-        curl \
-        lsb-release \
-        wget \
- && apt clean
+        wget
 
-# Setup and install ignition fortress, colcon and rosdep
-RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg' \
-  && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null' \
-  && apt update \
-  && apt install -y ignition-fortress \
-     python3-colcon-common-extensions \
-     python3-colcon-core \
-     python3-rosdep \
-     python3-vcstool \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt clean
-
-# Setup working environment
+# Using non-official Gazebo + ROS combination, set it explicitly
 ENV IGNITION_VERSION fortress
 
-# When running a container start in the user's home folder
-WORKDIR /home/${USERNAME}/
-
-# Add the same user as outside the container
-# Requires a docker build argument `USERNAME`
-ARG USERNAME
-RUN useradd -d /home/${USERNAME}/ -m -s /bin/bash $USERNAME
-
-# Create project directory, set permissions and import packages
+# Create project directory and import packages
 RUN mkdir -p /tmp/buoy_ws/src \
-  && chown -R $USERNAME:$USERNAME /tmp/buoy_ws \
-  && adduser $USERNAME sudo \
-  && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME \
   && cd /tmp/buoy_ws/src/ \
   && wget https://raw.githubusercontent.com/osrf/buoy_entrypoint/main/buoy_all.yaml \
-  && vcs import --skip-existing < buoy_all.yaml \
-  && chown -R $USERNAME:$USERNAME .
+  && vcs import < buoy_all.yaml
 
-# Run the commands below as non-root
-# USER ${USERNAME}
-
-# Install rosdep dependencies
+# Install rosdep dependencies - this installs Gazebo and other packages
 RUN sudo apt update \
   && cd /tmp/buoy_ws \
   && rosdep update \
   && rosdep install --from-paths src --ignore-src -r -y -i \
-  && sudo rm -rf /var/lib/apt/lists/* \
-  && sudo apt clean
+  && rm -rf /var/lib/apt/lists/* \
+  && apt clean
 
 # Build the project
 RUN /bin/bash -c 'source /opt/ros/${ROS_DISTRO}/setup.bash \
   && cd /tmp/buoy_ws \
   && colcon build'
 
-# Source workspaces, add it to the bashrc
-RUN /bin/sh -c 'echo ". /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/${USERNAME}/.bashrc' \
-  && /bin/sh -c 'echo ". /home/${USERNAME}/buoy_ws/install/setup.sh" >> /home/${USERNAME}/.bashrc'
+ENTRYPOINT ["/bin/bash" , "-c" , "source /tmp/buoy_ws/install/setup.bash && /bin/bash"]

--- a/docker/buoy/Dockerfile
+++ b/docker/buoy/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Necessary tools
 RUN apt update \
  && apt install -y \
+        apt-utils \
         wget
 
 # Using non-official Gazebo + ROS combination, set it explicitly


### PR DESCRIPTION
* Suggestions to #3

## Summary

* Only install tools that are used and aren't already in the base image. This means we don't need to re-install things like `lsb-release`, `colcon`, etc.
* Don't add http://packages.osrfoundation.org, instead, rely on the Fortress packages from http://packages.ros.org.
* I removed all the logic about `USERNAME`, I think `rocker` is handling that nicely for us already with the `--user` option - let me know if I'm missing some use case, @quarkytale 
* Used `ENTRYPOINT` to make sure the workspace is sourced
* Only `apt clean` after all updates

## Test it

Build

`./build.bash buoy`

Test simulation usage:

```
./run.bash -s buoy:latest
# Inside container you can just run
ign gazebo mbari_wec.sdf -r
```


## Open questions

* For the developer usage, I'd like to see the new docs from @quarkytale to understand the use case fully. Now that the workspace isn't in the home folder anymore, I'm not sure if the 2 use cases are very different.
* I'm concerned about building the workspace in `/tmp`, because that directory isn't meant for persistent files, although I don't think it should cause issues for the quick simulation use case. I think it would be better to put it in home like it was before, even if it collides with the user's mounted home.