### PR TITLE
Add documentation URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This is the entrypoint for the wave energy harvesting buoy project.
 
+See [documentation here](https://osrf.github.io/buoy_entrypoint).
+
 ## Repositories
 
 These are the repositories for the project:


### PR DESCRIPTION
While writing to someone about this repo, I realized that the documentation is not easily discoverable. Though the docs are still work in progress, it is good to put the documentation link at the top of the README, since there will be some publicity at the next Gazebo Community meeting.

Signed-off-by: Mabel Zhang <mabel@openrobotics.org>